### PR TITLE
SummingUp potions

### DIFF
--- a/src/main/java/think/rpgitems/power/impl/PotionSelf.java
+++ b/src/main/java/think/rpgitems/power/impl/PotionSelf.java
@@ -143,21 +143,8 @@ public class PotionSelf extends BasePower {
 
         @Override
         public PowerResult<Void> fire(Player player, ItemStack stack) {
-            final int[] summing = {0};
             List<ItemStack> items = new ArrayList<>(Arrays.asList(player.getInventory().getArmorContents()));
             items.add(player.getInventory().getItemInMainHand());
-            for(ItemStack i : items){
-                ItemManager.toRPGItemByMeta(i).ifPresent(rpgItem -> {
-                    for (Power power : rpgItem.getPowers()){
-                        if(power.getName().equals("potionself")) {
-                            PotionSelf potionSelf = (PotionSelf) power;
-                            if(potionSelf.getType()==getType()&&potionSelf.isSummingUp()){
-                                summing[0] += potionSelf.getAmplifier();
-                            }
-                        }
-                    }
-                });
-            }
             PowerActivateEvent powerEvent = new PowerActivateEvent(player,stack,getPower());
             if(!powerEvent.callEvent()) {
                 return PowerResult.fail();
@@ -167,7 +154,11 @@ public class PotionSelf extends BasePower {
             if (isClear()) {
                 player.removePotionEffect(getType());
             } else {
-                player.addPotionEffect(new PotionEffect(getType(), getDuration(), getAmplifier()+summing[0]));
+                try {
+                    player.addPotionEffect(new PotionEffect(getType(), getDuration(), isSummingUp() ? getAmplifier() + player.getPotionEffect(getType()).getAmplifier() + 1 : getAmplifier()));
+                } catch (NullPointerException e) {
+                    player.addPotionEffect(new PotionEffect(getType(), getDuration(), isSummingUp() ? getAmplifier() : getAmplifier()));
+                }
             }
             return PowerResult.ok();
         }

--- a/src/main/java/think/rpgitems/power/impl/PotionTick.java
+++ b/src/main/java/think/rpgitems/power/impl/PotionTick.java
@@ -145,6 +145,7 @@ public class PotionTick extends BasePower {
                         .map(power -> (PotionTick) power)
                         .filter(potionTick -> potionTick.getEffect() == getEffect() && potionTick.isSummingUp())
                         .mapToInt(PotionTick::getAmplifier)
+                        .map(amplifier -> amplifier + 1) // +1 because amplifier is 0-based
                         .sum();
 
                 totalAmplifier += additionalLevels - (isSummingUp() ? getAmplifier() : 0);
@@ -157,7 +158,7 @@ public class PotionTick extends BasePower {
             if (isClear() && hasMatchingEffect) {
                 player.removePotionEffect(getEffect());
             } else if (!isClear()) {
-                PotionEffect newEffect = new PotionEffect(getEffect(), getDuration(), totalAmplifier, true);
+                PotionEffect newEffect = new PotionEffect(getEffect(), getDuration(), totalAmplifier - 1, true);
                 player.addPotionEffect(newEffect);
             }
 


### PR DESCRIPTION
# Bug Fix

## Describe the Bug

`summingUp` flag for `potionself` and `potiontick` add amplifier for effects wrongly.

### New Behavior

summingUp correctly add effect amplifiers between items. It adds the granted levels to the current effect level of player.

### Minimum Example

For `potionself`: Using 2 items with Effect _a_ and Effect _b_ while _a_ has not ran out grants player Effect _a+b_. As an example Speed II + Speed IV will become Speed VI.

For `potiontick`: Wearing 2 items with Effect _a_ and Effect _b_ grants player Effect _a+b_. As an example Speed II helmet + Speed IV chestplate will grant Speed VI to player.