### PR TITLE
Cooldown reduction power and util

### DIFF
--- a/src/main/java/think/rpgitems/power/impl/CooldownReduce.java
+++ b/src/main/java/think/rpgitems/power/impl/CooldownReduce.java
@@ -1,0 +1,45 @@
+package think.rpgitems.power.impl;
+
+import org.bukkit.inventory.EquipmentSlotGroup;
+import think.rpgitems.I18n;
+import think.rpgitems.power.*;
+
+@Meta
+public class CooldownReduce extends BasePower {
+    @Property
+    public int amount = 1; // 100% or 1 tick reduction by default
+
+    public enum Operation {
+        SUBTRACT,
+        MULTIPLY
+    }
+
+    @Property
+    public Operation operation = Operation.MULTIPLY;
+
+    @Property
+    public EquipmentSlotGroup slot = null;
+
+    @Override
+    public String getName() {
+        return "cooldownreduce";
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public Operation getOperation() {
+        return operation;
+    }
+
+    public EquipmentSlotGroup getSlot() {
+        return slot;
+    }
+
+    @Override
+    public String displayText() {
+        // TODO: i18n
+        return I18n.formatDefault("power.cooldownreduce");
+    }
+}


### PR DESCRIPTION
# New Feature

- Added `CooldownReduce` power and helper function in `Utils`

## Usage
Reduce CD for all items by `x` ticks, or multiply CD by `x`, iff the item with the CDR power is equipped in specified slot(s).

This change resolves #4 by fulfilling the feature request.