### PR TITLE
Armor Ignore

### DIFF
--- a/src/main/java/think/rpgitems/AdminCommands.java
+++ b/src/main/java/think/rpgitems/AdminCommands.java
@@ -1621,6 +1621,22 @@ public class AdminCommands extends RPGCommandReceiver {
         return filtered(arguments, completeStr);
     }
 
+    @SubCommand(value = "armourignore", tabCompleter = "itemCompleter")
+    public void armourIgnore(CommandSender sender, Arguments args) {
+        RPGItem item = getItem(args.nextString(), sender);
+        if (args.top() == null) {
+            I18n.sendMessage(sender, "message.armourignore.get", item.getArmourIgnorePercent());
+            return;
+        }
+        int ignore = args.nextInt();
+        if (ignore < 0 || ignore > 100) {
+            throw new CommandException("message.armourignore.num_out_of_range", ignore, 0, 100);
+        }
+        item.setArmourIgnorePercent(ignore);
+        ItemManager.save(item);
+        I18n.sendMessage(sender, "message.armourignore.set", item.getName(), ignore);
+    }
+
     private void publishGist(CommandSender sender, Arguments args, Set<String> itemNames) {
         List<Pair<String, RPGItem>> items = itemNames.stream().map(i -> Pair.of(i, getItem(i, sender))).collect(Collectors.toList());
         Optional<Pair<String, RPGItem>> unknown = items.stream().filter(p -> p.getValue() == null).findFirst();

--- a/src/main/java/think/rpgitems/item/RPGItem.java
+++ b/src/main/java/think/rpgitems/item/RPGItem.java
@@ -128,6 +128,7 @@ public class RPGItem {
     private int armour = 0;
     private String armourExpression = "";
     private String playerArmourExpression = "";
+    private int armourIgnorePercent = 0;
     private String damageType = "";
     private boolean canBeOwned = false;
     private boolean canUse = false;
@@ -634,6 +635,7 @@ public class RPGItem {
         s.set("armour", getArmour());
         s.set("armourExpression", getArmourExpression());
         s.set("playerArmourExpression", getPlayerArmourExpression());
+        s.set("armorIgnorePercent", getArmourIgnorePercent());
         s.set("DamageType", getDamageType());
         s.set("updatemode", updateMode.name());
         s.set("attributemode", attributeMode.name());
@@ -2120,6 +2122,14 @@ public class RPGItem {
         if (update) {
             rebuild();
         }
+    }
+
+    public int getArmourIgnorePercent() {
+        return armourIgnorePercent;
+    }
+
+    public void setArmourIgnorePercent(int armourIgnorePercent) {
+        this.armourIgnorePercent = armourIgnorePercent;
     }
 
     public String getAuthor() {


### PR DESCRIPTION
# New Feature

- A new base parameter (`SubCommand`) for an `RPGItem` to ignore a set percent armour on targets hit when damage is dealt with said item

## Usage

- `/rpgitem armourignore <a item> <x percent>` will cause item `a` to ignore `x`% of the target's armour when target takes a hit
- For instance, if target has 20% armour, and player hits target with an item with 3 damage and 10% armour ignore, actual damage would be `3 * (1 - (0.2 * 0.9))`

A lot of this change is TBD, it would close #14 when completed but that would probably take some time